### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## 🛠 Changes
+
+<!-- What was added, updated, or removed in this PR. -->
+
+## ℹ️ Context
+
+<!-- Background context, more in-depth details of the implementation, and anything else you'd like to call out for reviewers. -->
+
+## 👀 Testing
+
+<!-- Validation that the code works as expected. Can be an explanation, video/screenshot demos, etc. -->
+
+## 📝 Relevant Issues
+
+<!-- Any related or resolved issues. --> 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,15 @@
-## 🛠 Changes
+## Changes
 
 <!-- What was added, updated, or removed in this PR. -->
 
-## ℹ️ Context
+## Context
 
 <!-- Background context, more in-depth details of the implementation, and anything else you'd like to call out for reviewers. -->
 
-## 👀 Testing
+## Testing
 
 <!-- Validation that the code works as expected. Can be an explanation, video/screenshot demos, etc. -->
 
-## 📝 Relevant Issues
+## Relevant Issues
 
 <!-- Any related or resolved issues. --> 


### PR DESCRIPTION
## Changes

Add PR template.

## Context

Adds a template that will auto-populate for new PRs. This is based on the format we've already started to use informally 👋 

## Testing

Copy-pasta'd the template into this PR description as an example.

## Relevant Issues

Closes #25.