### PR TITLE
Debugging getstream deployment issues 

### DIFF
--- a/client/.env.local.example
+++ b/client/.env.local.example
@@ -3,6 +3,7 @@ NEXT_PUBLIC_USE_PROD_SERVER=false
 
 # Set the API key for Stream viewing
 NEXT_PUBLIC_STREAM_API_KEY=my-stream-api-key
+NEXT_PUBLIC_STREAM_ADMIN_USER_ID=bhaviksingh
 
 # Set the API key for Honeycomb tracing
 NEXT_PUBLIC_HONEYCOMB_INGEST_API_KEY=my-ingest-api-key

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Node.js 16 image as a parent image
-FROM node:16
+# Use the official Node.js 18 image as a parent image
+FROM node:18
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/server/fly.toml
+++ b/server/fly.toml
@@ -12,7 +12,7 @@ primary_region = "ewr"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [[vm]]
   cpu_kind = "shared"

--- a/server/src/streamAPI.ts
+++ b/server/src/streamAPI.ts
@@ -27,7 +27,6 @@ export const streamUpdateWasReceived: RequestHandler = async (req, res) => {
     logInfo("** [POST] getStream HOOK")
     try {
         if (!req.body || !req.body.type) { 
-            console.log(req.body);
             throw Error("Badly formatted webhook");
          }
         const hook = req.body;
@@ -89,12 +88,12 @@ export const streamUpdateWasReceived: RequestHandler = async (req, res) => {
 
 export const createStreamAdminToken: RequestHandler = async (req, res) => {
     const roomId = req.params.id;
-
+    
     if (!roomId) {
         res.status(400).send("No room ID provided");
         return;
     }
-
+    console.log("> Creating stream admin token for room " + roomId);
     try {
         // exp is optional (by default the token is valid for an hour)
         const exp = Math.round(new Date().getTime() / 1000) + 60 * 60;


### PR DESCRIPTION
## Changes

A few simple fixes to get getStream to deploy. 

## Context

- Deploying main to server wasn't working, because `fetch` isn't globally defined <node 18.0.
- Additionally, making it so that at least 1 machine is always running. 

## Testing

- Tested in prod! 

## Relevant Issues
