### PR TITLE
Enable cam and mic selection

### DIFF
--- a/client/src/pages/[id]/stream.tsx
+++ b/client/src/pages/[id]/stream.tsx
@@ -271,9 +271,6 @@ const LivestreamView = ({
     liveParticipants,
   });
 
-  const labeledCamDevices = camDevices.filter((device) => device.label);
-  const labeledMicDevices = micDevices.filter((device) => device.label);
-
   let panelRef = createRef<HTMLDivElement>();
 
   return (
@@ -342,16 +339,16 @@ const LivestreamView = ({
                 >
                   {isCamEnabled ? "Disable camera" : "Enable camera"}
                 </button>
-                {labeledCamDevices.length > 0 && (
+                {isCamEnabled && camDevices.length > 0 && (
                   <select
                     value={call.camera.state.selectedDevice}
                     onChange={(event) => call.camera.select(event.target.value)}
                     className="padded:s-2"
                   >
-                    {labeledCamDevices.map((device) => {
+                    {camDevices.map((device, idx) => {
                       return (
                         <option key={device.deviceId} value={device.deviceId}>
-                          {device.label}
+                          {device.label || `Device ${idx}`}
                         </option>
                       );
                     })}
@@ -366,7 +363,7 @@ const LivestreamView = ({
                 >
                   {isMicEnabled ? "Mute Mic" : "Unmute Mic"}
                 </button>
-                {labeledMicDevices.length > 0 && (
+                {isMicEnabled && micDevices.length > 0 && (
                   <select
                     value={call.microphone.state.selectedDevice}
                     onChange={(event) =>
@@ -374,10 +371,10 @@ const LivestreamView = ({
                     }
                     className="padded:s-2"
                   >
-                    {labeledMicDevices.map((device) => {
+                    {micDevices.map((device, idx) => {
                       return (
                         <option key={device.deviceId} value={device.deviceId}>
-                          {device.label}
+                          {device.label || `Device ${idx}`}
                         </option>
                       );
                     })}

--- a/client/src/pages/[id]/stream.tsx
+++ b/client/src/pages/[id]/stream.tsx
@@ -208,11 +208,7 @@ const LivestreamView = ({
   const { useCameraState, useMicrophoneState, useIsCallLive, useParticipants } =
     useCallStateHooks();
 
-  const {
-    camera: cam,
-    selectedDevice: cameraId,
-    isEnabled: isCamEnabled,
-  } = useCameraState();
+  const { camera: cam, isEnabled: isCamEnabled } = useCameraState();
   const { microphone: mic, isEnabled: isMicEnabled } = useMicrophoneState();
   const [camDevices, setCamDevices] = useState<MediaDeviceInfo[]>([]);
   const [micDevices, setMicDevices] = useState<MediaDeviceInfo[]>([]);


### PR DESCRIPTION
## Changes

- Allows camera and microphone selection when devices are enabled.

## Context

It is what it is... = ) The microphone "human-readable" names didn't work for me for some reason but maybe they will work for others. I use "Device 0", "Device 1" etc. instead as a fallback.

## Testing

https://github.com/user-attachments/assets/093ca480-4b4f-45f0-897d-d289ead5776f

## Relevant Issues

#41 