### PR TITLE
Support long-term recordings storage

### DIFF
--- a/server/bin/configureRecordingStorage.js
+++ b/server/bin/configureRecordingStorage.js
@@ -7,7 +7,7 @@
 //
 // WHY:
 // By default, Stream offers their own storage and CDN, which should theoretically store videos up to 1-2 weeks.
-// In practice, the CDN link expiration only lasts a day.
+// In practice, the CDN link expires after a day.
 //
 // NOTE:
 // Stream webhooks for call.recording_ready will have an invalid stream-io-cdn URL and must be manually

--- a/server/bin/configureRecordingStorage.js
+++ b/server/bin/configureRecordingStorage.js
@@ -1,0 +1,63 @@
+// This script configures our own external storage for Stream recordings in Google Cloud.
+//
+// PRE-REQUISITES:
+// - A separate bucket needs to be made manually before running this script, and set to default public access for all objects.
+// - A service account needs to be created with Cloud Storage Object Creator permissions.
+// - A key JSON file needs to be created and downloaded. The JSON filename should be replaced below.
+//
+// WHY:
+// By default, Stream offers their own storage and CDN, which should theoretically store videos up to 1-2 weeks.
+// In practice, the CDN link expiration only lasts a day.
+//
+// NOTE:
+// Stream webhooks for call.recording_ready will have an invalid stream-io-cdn URL and must be manually
+// remapped to the public Cloud Storage URL. See streamAPI.ts.
+//
+import {
+    StreamClient,
+} from "@stream-io/node-sdk";
+import { dirname } from 'node:path';
+import dotenv from "dotenv";
+import { fileURLToPath } from 'node:url';
+import fs from "fs";
+import path from "path";
+
+dotenv.config();
+    
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const apiKey = process.env.STREAM_API_KEY
+const apiSecret = process.env.STREAM_API_SECRET
+const client = new StreamClient(apiKey, apiSecret);
+
+// UPDATE THIS FILENAME if you are creating external storage.
+const filePath = path.join(__dirname, 'is-this-thing-on-320a7-12875719edb4.json');
+const serviceAccountKeyJson = fs.readFileSync(filePath, {encoding: 'utf-8'});
+
+console.log("Creating external storage");
+
+await client.video.createExternalStorage({
+  bucket: "is-this-thing-on-recordings",
+  name: "stream-recordings-gcs",
+  storage_type: "gcs",
+  path: "stream_recordings/",
+  gcs_credentials: serviceAccountKeyJson,
+});
+
+console.log("Verifying storage");
+
+// Note: sometimes this fails if it's run immediately after creating the external storage.
+//       running it again with the createExternalStorage line commented out will work.
+await client.video.checkExternalStorage({
+  name: "stream-recordings-gcs",
+});
+
+console.log("Updating call type");
+
+await client.video.updateCallType("default", {
+  external_storage: "stream-recordings-gcs"
+});
+
+await client.video.updateCallType("livestream", {
+  external_storage: "stream-recordings-gcs"
+});

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
     "prod": "npm run build && node build/server.js",
     "dev": "tsc -w & nodemon --watch build build/server.js",
     "deploy": "flyctl deploy",
-    "tunnel": "ssh -R istomux.lhr.rocks:80:localhost:4000 localhost.run"
+    "tunnel": "ssh -R istomux.lhr.rocks:80:localhost:4000 localhost.run",
+    "configure-recordings": "node bin/configureRecordingStorage.js"
   },
   "keywords": [],
   "author": "",

--- a/server/src/streamAPI.ts
+++ b/server/src/streamAPI.ts
@@ -106,7 +106,7 @@ export const streamUpdateWasReceived: RequestHandler = async (req, res) => {
       console.log("recording ready for roomID: ", hook);
       const recording = hook.call_recording;
       if (recording) {
-        const ref = await writeRecordingToDB(roomID, recording.url, recording.start_time, recording.end_time);
+        const ref = await writeRecordingToDB(roomID, recording.url.replace("ohio.stream-io-cdn.com/", "storage.googleapis.com/is-this-thing-on-recordings//"), recording.start_time, recording.end_time);
         logUpdate(`Wrote recording to DB for room ${roomID} with ref ${ref.id}`);
       } else {
         logError(`Recording was ready but didn't exist`);


### PR DESCRIPTION
## Changes

- Testing long-term storage of recordings using our own Cloud Storage

## Context

By default, Stream offers their own storage and CDN, which should theoretically store videos up to 1-2 weeks. This doesn't seem to be the case in practice (the CDN link expiration only lasts a day.) We're getting clarification, but want to make sure we have this option available if necessary.

## Testing

Ran the script locally on my personal Stream account, seems to work:

https://github.com/user-attachments/assets/79cedc10-03bd-4c3c-86ef-d5c92184e85c

## Notes

- This requires a server change/deployment since the Stream webhook gives us an invalid recording URL. The Stream CDN hostname needs to be replaced with our Cloud Storage hostname.
- This just uses the direct Cloud Storage file URL. A more mature solution would be to set up a [Cloud CDN](https://cloud.google.com/cdn?hl=en) or some other CDN. Downloading directly from Cloud Storage probably impacts data transfer costs and potentially the speed of download — I have not done napkin math to figure out the cost impact of serving files this way.

## Relevant Issues

<!-- Any related or resolved issues. --> 