### PR TITLE
Improve presence performance

### DIFF
--- a/client/src/lib/firestore/presence.ts
+++ b/client/src/lib/firestore/presence.ts
@@ -1,8 +1,8 @@
-import { doc, getDoc, onSnapshot, setDoc, updateDoc } from "firebase/firestore";
+import { doc, onSnapshot, setDoc } from "firebase/firestore";
 
-import { logInfo } from "../logger";
 import { presenceCollection, presenceStatsDoc } from "./locations";
 
+// Make sure to update firestore-api.ts if you update this.
 const PRESENCE_LENGTH = 10 * 1000;
 
 export let activePresenceHeartbeat: NodeJS.Timeout | undefined;


### PR DESCRIPTION
## Changes & Context

**1. Prevent presence for visitors from being removed and added cyclically.**

I noticed the presence DB removing and re-adding viewers constantly. This PR increases the PRESENCE_LENGTH on the server-side to avoid flickering due to cleanup.

Flickering in DB:

https://github.com/user-attachments/assets/66a312e4-6825-4b9e-990f-7bea7dcfcef1

**2. Use `count()` aggregation function to avoid incurring multiple Firebase reads**

Instead of retrieving all documents in presence and checking the `.size`, use the `count()` aggregator function. The [Firebase docs](https://firebase.google.com/docs/firestore/query-data/aggregation-queries#pricing) say that it's 1 read per 1000 indexed entries scanned and I also verified this by analyzing the old and new queries:

```js
const options = { analyze : true };
const explainResults = await q.explain(options);

// Old query scaled based on number of presence docs; New query is always 1.
console.log("readops: ", explainResults.metrics.executionStats?.readOperations);
```

**3. Only update stats for rooms with viewers**

The server should only have to update stats for the viewer's current room, and the last room they were in.

**4. Avoid updating stats if viewer didn't move rooms between heartbeats**

If the viewer didn't move rooms at all, the stats should still be accurate without updates.

## Testing

I played around with a few browsers/private tabs and:

- the view counts still looked accurate when moving rooms, going to the homepage, leaving, etc
- verified there was no flickering in the view counter
- verified in debug logs that there was less activity overall (instead of {roomCount} presence calls for every heartbeat, only 0-2 presence calls for every heartbeat)

|before|after|
|---|---|
|![CleanShot 2024-12-28 at 15 01 32@2x](https://github.com/user-attachments/assets/f1567ca6-daf5-4e07-be1c-2b553f743bcc)|![CleanShot 2024-12-28 at 16 09 47@2x](https://github.com/user-attachments/assets/de86a2db-89e1-483d-ba62-570c99eff330)|


I also verified that these changes lower the number of Firebase reads. Tested with 13 rooms and 3-4 visitors, but I imagine these changes make a bigger difference with more rooms / streamers / visitors. 

The spikes below are when I reverted back to the main branch temporarily.

![CleanShot 2024-12-28 at 16 43 42@2x](https://github.com/user-attachments/assets/9373e24c-09d2-40de-bec4-ac7e7223354f)

## Relevant Issues

<!-- Any related or resolved issues. --> 