### PR TITLE
Set preferred video codec to VP9 to improve video quality and consistency

### DIFF
--- a/client/src/components/gates/streamGate.tsx
+++ b/client/src/components/gates/streamGate.tsx
@@ -58,6 +58,24 @@ const StreamGate: React.FunctionComponent<{
         return;
       }
       const myCall = myClient.call("livestream", streamPlaybackID);
+
+      if (useAdmin) {
+        try {
+          // On platforms that support it, vp9 should noticeably improve video performance and quality.
+          // https://getstream.io/blog/vp9-enhanced/
+          //
+          // Note that the client is smart enough to know which browsers are better off ignoring the preference and _not_ using vp9:
+          // https://github.com/GetStream/stream-video-js/pull/1434/files#diff-540455c9dc2f7f24d930eede0cd3689beb1fcd804d566c6e422a13b4c5affb30R103-R111
+          //
+          myCall.updatePublishOptions({
+            preferredCodec: "vp9",
+            forceSingleCodec: true,
+          });
+        } catch (e) {
+          logError("Tried and failed to update preferred codec to vp9: " + e);
+        }
+      }
+
       myCall
         .get()
         .then(() => {


### PR DESCRIPTION
(*requires testing on safari, mobile, maybe some additional devices)

## Changes

- Use new experimental flag to set preferred codec to VP9 when device/platform supports it

## Context

As announced last month, VP9 is now supported and should provide the same video quality with less bandwidth / data transfer required:

https://getstream.io/blog/vp9-enhanced/

We saw lots of quality drops during NO-THING and from my initial testing, VP9 seems to help a good amount. Note that this currently only helps Chrome and Android devices — Safari and IOS still use h264 because of hardware acceleration, and Firefox has some "intermittent" issues for now when not streaming using vp8.

https://github.com/GetStream/stream-video-js/pull/1434/

## Testing

Verified locally that viewing my stream in Firefox looks the same, and viewing in Chrome looks better overall (still drops sometimes, but it basically shifts the quality window up and prevents the stream from looking like a baked potato when I open it up.)

VP8 in Chrome:

https://github.com/user-attachments/assets/7d8dc1e4-9f64-4a36-a5f8-72a56e7402a5

VP9 in Chrome:

https://github.com/user-attachments/assets/09fbe12a-b925-49f9-b8d5-bb25cd977ed5

